### PR TITLE
etcd and etcdctl changed paths

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,8 +31,8 @@ parts:
     plugin: go
     go-importpath: github.com/coreos/etcd
     go-packages:
-      - github.com/coreos/etcd/cmd/etcd
-      - github.com/coreos/etcd/cmd/etcdctl
+      - github.com/coreos/etcd
+      - github.com/coreos/etcd/etcdctl
     after: [go]
   etcd-wrapper:
     plugin: dump


### PR DESCRIPTION
If I read this PR correctly https://github.com/coreos/etcd/commit/b1e87f8ae1b4629cc07ade4fbe12caa4401b8a34 some paths have changed. I think we haven't had a green build for the past few months https://build.snapcraft.io/user/tvansteenburgh/etcd-snaps 