### PR TITLE
Use go 1.10 because it seems to be available for s390x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,8 +34,8 @@ parts:
       apt-get -y install software-properties-common
       add-apt-repository ppa:gophers/archive
       apt-get update
-      apt-get install golang-1.9-go -y
-      export PATH=$PATH:/usr/lib/go-1.9/bin
+      apt-get install golang-1.10-go -y
+      export PATH=$PATH:/usr/lib/go-1.10/bin
       export SNAP_ROOT="$(readlink -f .)"
       export GOPATH=$SNAP_ROOT/gopath
       git clone https://github.com/coreos/etcd.git -b v3.2.9 --depth 1


### PR DESCRIPTION
LP builder fail to install go 1.9 https://launchpadlibrarian.net/379272298/buildlog_snap_ubuntu_xenial_s390x_etcd_BUILDING.txt.gz

Seems we have go 1.10 for s390x http://ppa.launchpad.net/gophers/archive/ubuntu/pool/main/g/golang-1.10/ but we do not have go 1.9 http://ppa.launchpad.net/gophers/archive/ubuntu/pool/main/g/golang-1.9/

We can only hope.