### PR TITLE
Enable API v2 support

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -3,6 +3,10 @@
 # Human-readable name for this member.
 name: 'default'
 
+# Enable API v2 support for flannel and 
+# certain charm executions.
+enable-v2: true
+
 # Path to the data directory.
 data-dir:
 


### PR DESCRIPTION
Bug (for us) introduced in etcd 3.4 (https://github.com/etcd-io/etcd/pull/10935/files).  Needs enabling for Flannel and our charm code.

Tested, manually, on running cluster.