### PR TITLE
 Update v3.4 branch to v3.4.5 and add unsupported arch handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build Snap
+
+# Controls when the action will run. Triggers the workflow on push to any branch
+on: push
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v2
+    - uses: jhenstridge/snapcraft-build-action@v1
+      id: snapcraft
+    - name: Test snap
+      run: sudo ./test_snap.sh ${{ steps.snapcraft.outputs.snap }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: etcd.snap
+        path: ${{ steps.snapcraft.outputs.snap }}

--- a/bin/snap-wrap.sh
+++ b/bin/snap-wrap.sh
@@ -34,6 +34,9 @@ else
   exit 0
 fi
 
+# Attempt to force etcd to run on the current architecture.
+export ETCD_UNSUPPORTED_ARCH=`python3 -c "import platform; print({'aarch64':'arm64','s390x':'s390x'}.get(platform.machine(),''))"`
+
 # Launch with the default config file
 exec $SNAP/bin/etcd --config-file $TARGET_CONF "$@"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: '3.4.0'
+version: '3.4.5'
 summary: Distributed reliable key-value store
 description: |
   Etcd is a high availability key-value store, implementing the Raft
@@ -23,7 +23,7 @@ parts:
     plugin: go
     go-channel: 1.12/stable
     source: http://github.com/etcd-io/etcd.git
-    source-tag: v3.4.0
+    source-tag: v3.4.5
     go-importpath: github.com/etcd-io/etcd
     go-packages:
       - github.com/etcd-io/etcd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,13 +21,12 @@ apps:
 parts:
   etcd:
     plugin: go
-    go-channel: 1.12/stable
+    go-channel: 1.13/stable
     source: http://github.com/etcd-io/etcd.git
     source-tag: v3.4.5
-    go-importpath: github.com/etcd-io/etcd
-    go-packages:
-      - github.com/etcd-io/etcd
-      - github.com/etcd-io/etcd/etcdctl
+    override-build: |
+      go build -o /root/parts/etcd/install/bin/etcd go.etcd.io/etcd
+      go build -o /root/parts/etcd/install/bin/etcdctl go.etcd.io/etcd/etcdctl
   etcd-wrapper:
     plugin: dump
     source: .


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/etcd-snaps/+bug/1869232

Despite upstream docs to the contrary, recent versions of 3.4 require go
1.13 or greater, because they use go mod.

When go mod is in play, there's bug in snapcraft that:

- if you build w/o go-packages, too many binaries are built, where
snapcraft is expecting just one, and snapcraft exits with an error
- if you build *with* go-packages to avoid the previous error, the
correct output dir is not passed to 'go build' and so snapcraft again
exits with an error, thinking that *no* binaries have been built

And that's the reason for the 'override-build' section.